### PR TITLE
feat: :adhesive_bandage: forecast warning once per day

### DIFF
--- a/autodate.js
+++ b/autodate.js
@@ -5,13 +5,13 @@ const date = dateTime.getDate();
 
 let dayString = date.toString();
 const lastDigit = dayString.charAt(dayString.length - 1);
-if (dayString === '11' || dayString === '12' || dayString === '13') {
+if (dayString === "11" || dayString === "12" || dayString === "13") {
   dayString += "th";
-} else if (lastDigit === '1') {
+} else if (lastDigit === "1") {
   dayString += "st";
-} else if (lastDigit === '2') {
+} else if (lastDigit === "2") {
   dayString += "nd";
-} else if (lastDigit === '3') {
+} else if (lastDigit === "3") {
   dayString += "rd";
 } else {
   dayString += "th";

--- a/index.js
+++ b/index.js
@@ -131,6 +131,7 @@ if (options.config) {
         { title: "Show API key", value: "show" },
         { title: "Delete API key", value: "delete" },
         { title: "Set temperature unit", value: "unit" },
+        { title: "Clear config", value: "clear" },
         { title: "Cancel", value: "cancel" },
       ],
     });
@@ -164,6 +165,10 @@ if (options.config) {
       });
       await config.set("unit", unit.unit);
       console.log(chalk.green("Temperature unit saved as " + config.get("unit") + "."));
+    }
+    if (response.config === "clear") {
+      await config.clear();
+      console.log(chalk.green("Config cleared."));
     }
     process.exit(0);
   })();


### PR DESCRIPTION
# Description

Forecast API warning will now only be shown once a day so it does not bother the user when making many requests on the same day.
Added new config item "forecast_api" that stores last day forecast api was used. If this matches the current day, the warning will not be displayed.

Fixes #26 (issue)

## Type of change

Please delete options that are not relevant.

- [ x Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commits follow the Conventional Commits Specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings