### PR TITLE
feat(ux): :children_crossing: option to exit forecast from day selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@suptower/weather-cli",
 	"version": "0.4.5",
-	"date": "Updated on 31st of July 2023.",
+	"date": "Updated on 1st of August 2023.",
 	"description": "A package to retrieve weather information directly from your terminal.",
 	"exports": "./index.js",
 	"type": "module",

--- a/weather.js
+++ b/weather.js
@@ -222,15 +222,21 @@ const getForecast = async (response, days) => {
       console.log(
         chalk.yellow("Data has been fetched for " + chalk.cyan(response.forecast.forecastday.length) + " days."),
       );
-      // Let user select a day
+      // Let user select a day or exit
+      const dayChoices = response.forecast.forecastday.map(day => {
+        return { title: day.date, value: day };
+      });
+      dayChoices.push({ title: "Exit", value: "exit" });
       await prompts({
         type: "select",
         name: "value",
         message: "Select a day",
-        choices: response.forecast.forecastday.map(day => {
-          return { title: day.date, value: day };
-        }),
+        choices: dayChoices,
       }).then(day => {
+        if (day.value === "exit") {
+          console.log(chalk.red("Exiting..."));
+          return;
+        }
         console.log(
           chalk.blue("You selected " + chalk.cyan(day.value.date) + ". Data will be shown for " + chalk.cyan("12 PM.")),
         );


### PR DESCRIPTION
# Description

User can now exit tool in forecast day selection without needing to enter a day in order to be able to exit the application.

Fixes #30  (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commits follow the Conventional Commits Specification
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings